### PR TITLE
Add interactive campaign builder and evaluation workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,16 @@ pip install -r requirements.txt
 - Rename `models.yaml.local` to `models.yaml`.
 - Run the app with `python app.py`.
 
+## New Capabilities
+
+### Interactive Campaign Builder
+- Launch the **Interactive Campaign Builder** tab to collaborate with the marketing co-pilot in a chat-style workflow.
+- Provide the product, campaign, and industry context, start a session, and iterate on research follow-ups or copy revisions directly in the conversation.
+
+### Agent Evaluation Dashboard
+- Capture qualitative feedback and optional automated LLM evaluations from within the builder workflow.
+- Explore saved sessions, human feedback, and automated quality scores under the **Agent Evaluation Dashboard** tab for continuous improvement.
+
 ## Notes
 - The app will generate images in the `generated_images` folder.
 - The app will save the fine-tuned model in the GCS bucket. You need to have the `gc_service_account_key.json` file in the same folder as the `app.py` file. You also need to update the `GCS_BUCKET_NAME` in the `.env` file.

--- a/app.py
+++ b/app.py
@@ -22,6 +22,16 @@ from image_gen import (
     get_model_details
 )
 import time
+from typing import Dict, List, Tuple
+
+from evaluation import (
+    FeedbackLogger,
+    build_feedback_entry,
+    run_quality_evaluation,
+)
+from langchain_core.output_parsers import StrOutputParser
+from langchain_openai import ChatOpenAI
+from langchain_core.prompts import ChatPromptTemplate
 
 # Load environment variables from .env file
 load_dotenv()
@@ -159,6 +169,194 @@ def clear_image_inputs():
     }
 
 
+feedback_logger = FeedbackLogger()
+
+
+def transcript_from_history(history: List[Tuple[str, str]]) -> str:
+    """Convert a chatbot history into a readable transcript."""
+
+    if not history:
+        return "No prior conversation."
+
+    lines = []
+    for turn in history:
+        if not isinstance(turn, tuple) or len(turn) != 2:
+            continue
+        user_msg, assistant_msg = turn
+        if user_msg:
+            lines.append(f"User: {user_msg}")
+        if assistant_msg:
+            lines.append(f"Assistant: {assistant_msg}")
+    return "\n".join(lines) if lines else "No prior conversation."
+
+
+def history_to_records(history: List[Tuple[str, str]]) -> List[Dict[str, str]]:
+    """Convert chatbot history into role-based records."""
+
+    records: List[Dict[str, str]] = []
+    for turn in history or []:
+        if not isinstance(turn, tuple) or len(turn) != 2:
+            continue
+        user_msg, assistant_msg = turn
+        if user_msg:
+            records.append({"role": "user", "content": user_msg})
+        if assistant_msg:
+            records.append({"role": "assistant", "content": assistant_msg})
+    return records
+
+
+def start_interactive_session(product, campaign, industry):
+    """Initialize a new interactive editing session."""
+
+    if not product or not campaign or not industry:
+        raise gr.Error("Please provide product, campaign, and industry details to begin.")
+
+    assistant_intro = (
+        "Thanks for the context! Let's iteratively improve this campaign. "
+        "Share any goals, edits, or new research questions and I'll respond with "
+        "targeted recommendations."
+    )
+    initial_history = [("", assistant_intro)]
+    return initial_history, initial_history
+
+
+def interactive_response(message, history, product, campaign, industry):
+    """Generate a response from the interactive campaign editing assistant."""
+
+    history = history or []
+
+    if not message:
+        return history, history, ""
+
+    if not product or not campaign or not industry:
+        history.append(
+            (
+                message,
+                "Please provide product, campaign, and industry details before chatting.",
+            )
+        )
+        return history, history, ""
+
+    try:
+        api_key = os.getenv("OPENAI_API_KEY")
+        if not api_key:
+            raise ValueError("OPENAI_API_KEY environment variable is not set.")
+
+        transcript = transcript_from_history(history)
+        model = ChatOpenAI(model="gpt-4o-mini", api_key=api_key)
+        prompt = ChatPromptTemplate.from_template(
+            """
+You are an expert lifecycle marketing strategist collaborating with a human marketer.
+Product description: {product}
+Campaign description: {campaign}
+Industry: {industry}
+
+Conversation so far:
+{history}
+
+The marketer just said: {message}
+
+Provide a concise, actionable response that either suggests research directions,
+revisions to the brief, or specific email content improvements. Offer numbered
+options when proposing multiple ideas and end with a clarifying question when helpful.
+"""
+        )
+
+        response = prompt | model | StrOutputParser()
+        assistant_message = response.invoke(
+            {
+                "product": product,
+                "campaign": campaign,
+                "industry": industry,
+                "history": transcript,
+                "message": message,
+            }
+        )
+    except Exception as exc:
+        assistant_message = (
+            "I ran into an issue while generating a response: " f"{exc}."
+            " Please verify your API configuration and try again."
+        )
+
+    updated_history = history + [(message, assistant_message)]
+    return updated_history, updated_history, ""
+
+
+def reset_interactive_session():
+    """Clear the interactive session state."""
+
+    return [], [], ""
+
+
+def submit_feedback(
+    rating,
+    comments,
+    history,
+    product,
+    campaign,
+    industry,
+    run_automated_eval,
+):
+    """Persist human feedback and optionally run automated evaluation."""
+
+    conversation_records = history_to_records(history)
+    if not conversation_records:
+        raise gr.Error("There is no conversation history to evaluate.")
+
+    automated_evaluation = None
+    evaluation_error = None
+    if run_automated_eval:
+        try:
+            automated_evaluation = run_quality_evaluation(
+                conversation_records,
+                product_description=product,
+                campaign_description=campaign,
+                industry=industry,
+            )
+        except Exception as exc:
+            evaluation_error = str(exc)
+            automated_evaluation = {"error": evaluation_error}
+
+    entry = build_feedback_entry(
+        conversation=conversation_records,
+        product_description=product,
+        campaign_description=campaign,
+        industry=industry,
+        rating=int(rating) if rating is not None else None,
+        comments=comments,
+        automated_evaluation=automated_evaluation,
+    )
+    saved_file = feedback_logger.save_feedback(entry)
+
+    status_lines = [f"✅ Feedback saved as {saved_file}."]
+    if evaluation_error:
+        status_lines.append(f"⚠️ Automated evaluation failed: {evaluation_error}")
+    elif run_automated_eval:
+        status_lines.append("🤖 Automated evaluation completed.")
+
+    updated_choices = feedback_logger.list_feedback_files()
+
+    return (
+        gr.update(value="\n".join(status_lines), visible=True),
+        automated_evaluation,
+        gr.update(choices=updated_choices),
+    )
+
+
+def refresh_feedback_files():
+    """Refresh the dropdown containing saved feedback logs."""
+
+    return gr.update(choices=feedback_logger.list_feedback_files())
+
+
+def load_feedback_entry(file_name):
+    """Load a feedback entry for inspection."""
+
+    if not file_name:
+        return {}
+    return feedback_logger.load_feedback(file_name)
+
+
 class GCSBucketManager:
     def __init__(self, bucket_name, credentials_path):
         self.bucket_name = bucket_name
@@ -264,6 +462,128 @@ with gr.Blocks() as app:
                 processing_status,
                 pdf_output,
             ],
+        )
+
+    with gr.Tab("Interactive Campaign Builder"):
+        interactive_history_state = gr.State([])
+
+        with gr.Row():
+            with gr.Column(scale=1):
+                product_input_chat = gr.Textbox(
+                    label="Product Description",
+                    placeholder="Provide the product background for the interactive session...",
+                )
+                campaign_input_chat = gr.Textbox(
+                    label="Campaign Description",
+                    placeholder="Describe the campaign goals or theme...",
+                )
+                industry_input_chat = gr.Textbox(
+                    label="Industry",
+                    placeholder="Which industry are we targeting?",
+                )
+                start_session_btn = gr.Button("Start Interactive Session")
+
+            with gr.Column(scale=2):
+                chatbot = gr.Chatbot(
+                    label="Marketing Co-Pilot",
+                    height=350,
+                )
+                user_message_box = gr.Textbox(
+                    label="Your Message",
+                    placeholder="Ask for revisions, new angles, or research follow-ups...",
+                    lines=4,
+                )
+                with gr.Row():
+                    send_message_btn = gr.Button("Send", variant="primary")
+                    reset_session_btn = gr.Button("Reset Session")
+
+        with gr.Accordion("Feedback & Evaluation", open=False):
+            rating_slider = gr.Slider(
+                minimum=1,
+                maximum=5,
+                step=1,
+                value=4,
+                label="How helpful was the assistant?",
+            )
+            feedback_comments = gr.Textbox(
+                label="Additional Feedback",
+                placeholder="Share what went well or what could improve...",
+                lines=3,
+            )
+            run_eval_checkbox = gr.Checkbox(
+                label="Run automated quality evaluation",
+                value=True,
+            )
+            submit_feedback_btn = gr.Button("Submit Feedback & Save Session", variant="secondary")
+            feedback_status = gr.Markdown(visible=False)
+            evaluation_output = gr.JSON(label="Automated Evaluation", value=None)
+
+        start_session_btn.click(
+            fn=start_interactive_session,
+            inputs=[product_input_chat, campaign_input_chat, industry_input_chat],
+            outputs=[chatbot, interactive_history_state],
+        )
+
+        send_message_btn.click(
+            fn=interactive_response,
+            inputs=[
+                user_message_box,
+                interactive_history_state,
+                product_input_chat,
+                campaign_input_chat,
+                industry_input_chat,
+            ],
+            outputs=[chatbot, interactive_history_state, user_message_box],
+        )
+
+        reset_session_btn.click(
+            fn=reset_interactive_session,
+            inputs=[],
+            outputs=[chatbot, interactive_history_state, user_message_box],
+        )
+
+    with gr.Tab("Agent Evaluation Dashboard"):
+        with gr.Column():
+            gr.Markdown(
+                """
+Use this dashboard to inspect previously saved interactive sessions and their evaluations.
+Select a feedback file to review the conversation transcript, human feedback, and any
+automated scoring results.
+"""
+            )
+            feedback_file_dropdown = gr.Dropdown(
+                label="Saved Feedback Sessions",
+                choices=feedback_logger.list_feedback_files(),
+                value=None,
+                allow_custom_value=False,
+            )
+            refresh_feedback_btn = gr.Button("Refresh Saved Sessions")
+            loaded_feedback_output = gr.JSON(label="Session Details", value=None)
+
+        refresh_feedback_btn.click(
+            fn=refresh_feedback_files,
+            inputs=[],
+            outputs=[feedback_file_dropdown],
+        )
+
+        feedback_file_dropdown.change(
+            fn=load_feedback_entry,
+            inputs=[feedback_file_dropdown],
+            outputs=[loaded_feedback_output],
+        )
+
+        submit_feedback_btn.click(
+            fn=submit_feedback,
+            inputs=[
+                rating_slider,
+                feedback_comments,
+                interactive_history_state,
+                product_input_chat,
+                campaign_input_chat,
+                industry_input_chat,
+                run_eval_checkbox,
+            ],
+            outputs=[feedback_status, evaluation_output, feedback_file_dropdown],
         )
 
     with gr.Tab("Generate Image"):

--- a/evaluation.py
+++ b/evaluation.py
@@ -1,0 +1,136 @@
+"""Utilities for collecting human feedback and running automated evaluations."""
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass, asdict
+from datetime import datetime
+from typing import Dict, List, Optional
+
+from langchain_core.output_parsers import JsonOutputParser
+from langchain_core.prompts import ChatPromptTemplate
+from langchain_openai import ChatOpenAI
+
+
+@dataclass
+class FeedbackEntry:
+    """Container for a single feedback record."""
+
+    timestamp: str
+    product_description: str
+    campaign_description: str
+    industry: str
+    conversation: List[Dict[str, str]]
+    user_rating: Optional[int] = None
+    user_comments: Optional[str] = None
+    automated_evaluation: Optional[Dict[str, str]] = None
+
+
+class FeedbackLogger:
+    """Persist feedback entries to disk for later analysis."""
+
+    def __init__(self, base_dir: str = "evaluations") -> None:
+        self.base_dir = base_dir
+        os.makedirs(self.base_dir, exist_ok=True)
+
+    def save_feedback(self, entry: FeedbackEntry) -> str:
+        """Persist a feedback entry to disk and return the saved path."""
+
+        timestamp = entry.timestamp.replace(":", "-")
+        file_name = f"feedback_{timestamp}.json"
+        file_path = os.path.join(self.base_dir, file_name)
+        with open(file_path, "w", encoding="utf-8") as f:
+            json.dump(asdict(entry), f, ensure_ascii=False, indent=2)
+        return file_name
+
+    def list_feedback_files(self) -> List[str]:
+        """Return a sorted list of all stored feedback artifacts."""
+
+        files = [
+            file_name
+            for file_name in os.listdir(self.base_dir)
+            if file_name.endswith(".json")
+        ]
+        return sorted(files)
+
+    def load_feedback(self, file_name: str) -> Dict[str, object]:
+        """Load a feedback artifact into memory."""
+
+        file_path = os.path.join(self.base_dir, file_name)
+        with open(file_path, "r", encoding="utf-8") as f:
+            return json.load(f)
+
+
+def build_feedback_entry(
+    conversation: List[Dict[str, str]],
+    product_description: str,
+    campaign_description: str,
+    industry: str,
+    rating: Optional[int],
+    comments: Optional[str],
+    automated_evaluation: Optional[Dict[str, str]] = None,
+) -> FeedbackEntry:
+    """Create a feedback entry with a normalized timestamp."""
+
+    timestamp = datetime.utcnow().isoformat(timespec="seconds") + "Z"
+    return FeedbackEntry(
+        timestamp=timestamp,
+        product_description=product_description,
+        campaign_description=campaign_description,
+        industry=industry,
+        conversation=conversation,
+        user_rating=rating,
+        user_comments=comments,
+        automated_evaluation=automated_evaluation,
+    )
+
+
+def run_quality_evaluation(
+    conversation: List[Dict[str, str]],
+    product_description: str,
+    campaign_description: str,
+    industry: str,
+) -> Dict[str, str]:
+    """Use an LLM to score the conversation quality and surface action items."""
+
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        raise ValueError("OPENAI_API_KEY environment variable is not set.")
+
+    llm = ChatOpenAI(model="gpt-4o-mini", api_key=api_key)
+    parser = JsonOutputParser()
+    prompt = ChatPromptTemplate.from_messages(
+        [
+            (
+                "system",
+                """You are an expert marketing operations leader tasked with evaluating an
+                AI assistant that designs email campaigns. Review the conversation between
+                the marketer and the assistant. Provide constructive feedback, numerical
+                quality scores (1-5 scale), and identify concrete next actions for the
+                assistant to improve the campaign. Return a JSON object that matches the
+                following schema:
+                {"alignment_score": "1-5 score as string",
+                 "clarity_score": "1-5 score as string",
+                 "actionability_score": "1-5 score as string",
+                 "summary": "one paragraph summary of the assistant performance",
+                 "next_steps": ["Ordered list of next actions for the assistant"]}
+                """,
+            ),
+            (
+                "human",
+                """Conversation history:\n{conversation}\n\nProduct description: {product}\nCampaign description: {campaign}\nIndustry: {industry}\n\nProvide the evaluation now.""",
+            ),
+        ]
+    )
+
+    formatted_conversation = json.dumps(conversation, ensure_ascii=False, indent=2)
+
+    chain = prompt | llm | parser
+    return chain.invoke(
+        {
+            "conversation": formatted_conversation,
+            "product": product_description,
+            "campaign": campaign_description,
+            "industry": industry,
+        }
+    )


### PR DESCRIPTION
## Summary
- add a chat-based Interactive Campaign Builder tab with session state, messaging, and feedback capture
- introduce reusable evaluation utilities to log feedback and run automated quality reviews
- document the new interactive workflow and evaluation dashboard in the README

## Testing
- python -m compileall app.py evaluation.py

------
https://chatgpt.com/codex/tasks/task_e_68e4ba93053c832dadbd4797d9535d58